### PR TITLE
Request-Id Propagation and Centralized Syslog Logging

### DIFF
--- a/.github/workflows/ci_job.yml
+++ b/.github/workflows/ci_job.yml
@@ -109,13 +109,14 @@ jobs:
 
       - name: Start production stack
         run: |
-          docker compose up climateclaw code-server web-search-server -d --wait --build --remove-orphans || {
-            docker compose ps -a
-            docker compose logs climateclaw
-            docker compose logs code-server
-            docker compose logs web-search-server
-            docker compose logs mongodb
-            docker compose logs litellm
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml up climateclaw code-server web-search-server -d --wait --build --remove-orphans || {
+            docker ps -a
+
+            docker compose \
+              -f docker-compose.yml \
+              -f docker-compose.ci.yml \
+              logs climateclaw mongodb code-server web-search-server litellm
+
             exit 1
           }
 
@@ -128,4 +129,4 @@ jobs:
 
       - name: Tear down production stack
         if: always()
-        run: docker compose down -v
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v

--- a/.github/workflows/ci_job.yml
+++ b/.github/workflows/ci_job.yml
@@ -102,6 +102,7 @@ jobs:
           CLIMATECLAW_MONGODB_PASSWORD=ci-psswrd
           CLIMATECLAW_MONGODB_DATABASE_NAME=ci-db
           CLIMATECLAW_OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
+          CLIMATECLAW_SYSLOG_ADDRESS=tcp@localhost:1514
           EOF
 
       - name: Build production base image

--- a/.github/workflows/ci_job.yml
+++ b/.github/workflows/ci_job.yml
@@ -105,7 +105,7 @@ jobs:
           EOF
 
       - name: Build production base image
-        run: docker compose docker-compose.yml -f docker-compose.ci.yml --profile build-only build climateclaw-base
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml --profile build-only build climateclaw-base
 
       - name: Start production stack
         run: |

--- a/.github/workflows/ci_job.yml
+++ b/.github/workflows/ci_job.yml
@@ -105,7 +105,7 @@ jobs:
           EOF
 
       - name: Build production base image
-        run: docker compose --profile build-only build climateclaw-base
+        run: docker compose docker-compose.yml -f docker-compose.ci.yml --profile build-only build climateclaw-base
 
       - name: Start production stack
         run: |

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,4 @@
+services:
+  litellm:
+    logging:
+      driver: json-file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,11 @@ services:
         --run_gunicorn
         --detailed_debug
         2>&1 | tee -a /app/logs/litellm.log
+    logging:
+      driver: syslog
+      options:
+        syslog-address: "${CLIMATECLAW_SYSLOG_ADDRESS:?Set CLIMATECLAW_SYSLOG_ADDRESS}"
+        tag: "litellm-${CLIMATECLAW_INSTANCE_NAME}"
     env_file: .env
     networks:
       - climateclaw

--- a/docker/code-server/pyproject.toml
+++ b/docker/code-server/pyproject.toml
@@ -6,7 +6,8 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.116.1",
-    "fastmcp>=2.12.4",
+    "fastmcp==3.4.2",
+    "mcp==1.28.1",
     "httpx>=0.28.1",
     "ipython>=9.6.0",
     "jupyter-client>=8.6.3",

--- a/docker/rag-server/pyproject.toml
+++ b/docker/rag-server/pyproject.toml
@@ -6,7 +6,8 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.116.1",
-    "fastmcp>=2.12.4",
+    "fastmcp==3.4.2",
+    "mcp==1.28.1",
     "httpx>=0.28.1",
     "langchain-community>=0.3.31",
     "litellm>=1.76.2",

--- a/docker/web-search-server/pyproject.toml
+++ b/docker/web-search-server/pyproject.toml
@@ -6,7 +6,8 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.116.1",
-    "fastmcp>=2.12.4",
+    "fastmcp==3.4.2",
+    "mcp==1.28.1",
     "httpx>=0.28.1",
     "uvicorn[standard]>=0.35.0",
     "openai",

--- a/gen_compose.py
+++ b/gen_compose.py
@@ -148,12 +148,22 @@ def generate_haproxy(
     timeout,
 ):
     conf = []
+    request_id_rules = (
+        "    http-request set-header X-Request-Id %[req.hdr(X-Request-Id),default(%[uuid()])]\n"
+        "    declare capture request len 64\n"
+        "    http-request capture req.hdr(X-Request-Id) id 0\n"
+    )
 
     conf.append(
         "global\n"
         "    daemon\n"
-        "    maxconn 256\n"
-        f"    log {os.environ.get('CLIMATECLAW_SYSLOG_TARGET', 'stdout')} format raw local0 info\n\n"
+        "    maxconn 1024\n"
+        "    log stdout format raw local0 info\n"
+        f"    log {os.environ.get('CLIMATECLAW_SYSLOG_TARGET', 'stdout')} local0 info\n"
+        "    stats socket /var/run/haproxy.sock mode 660 level admin\n"
+    )
+
+    conf.append(
         "defaults\n"
         "    mode http\n"
         "    timeout connect 5s\n"
@@ -161,31 +171,39 @@ def generate_haproxy(
         f"    timeout server {timeout}s\n"
         "    default-server inter 3s fall 3 rise 2\n"
         "    log     global\n"
-        '    log-format "%t %ci:%cp %ft %b/%s Tq=%Tq Tw=%Tw Tc=%Tc Tr=%Tr Tt=%Tt '
-        'status=%ST bytes=%B term=%ts conn=%ac/%fc/%bc/%sc/%rc %{+Q}r"\n'
+        "    option  httplog\n"
+        "    log-format '%t %ci:%cp %ft %b/%s Tq=%Tq Tw=%Tw Tc=%Tc Tr=%Tr Tt=%Tt "
+        "status=%ST bytes=%B term=%ts conn=%ac/%fc/%bc/%sc/%rc "
+        "request_id=%[capture.req.hdr(0)] %{+Q}r'\n"
     )
 
     conf.append(
         "frontend fe_backend\n"
         f"    bind *:{backend_port}\n"
+        f"{request_id_rules}"
         "    default_backend be_climateclaw\n"
-        "\n"
     )
 
     conf.append(
-        "frontend fe_litellm\n    bind *:4000\n    default_backend be_litellm\n\n"
+        "frontend fe_litellm\n"
+        "    bind *:4000\n"
+        f"{request_id_rules}"
+        "    default_backend be_litellm\n"
     )
 
     conf.append(
-        "frontend fe_ollama\n    bind *:11434\n    default_backend be_ollama\n\n"
+        "frontend fe_ollama\n"
+        "    bind *:11434\n"
+        f"{request_id_rules}"
+        "    default_backend be_ollama\n"
     )
 
     for s in server_list:
         conf.append(
             f"frontend fe_{s}\n"
             f"    bind *:{port_dict[s]}\n"
+            f"{request_id_rules}"
             f"    default_backend be_{s}\n"
-            "\n"
         )
 
     conf.append(

--- a/gen_compose.py
+++ b/gen_compose.py
@@ -149,7 +149,7 @@ def generate_haproxy(
 ):
     conf = []
     request_id_rules = (
-        "    http-request set-header X-Request-Id %[req.hdr(X-Request-Id),default(%[uuid()])]\n"
+        "    http-request set-header X-Request-Id %[uuid()] unless { req.hdr(X-Request-Id) -m found }\n"
         "    declare capture request len 64\n"
         "    http-request capture req.hdr(X-Request-Id) id 0\n"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ classifiers = [
 dependencies = [
     "anyio",
     "fastapi",
-    "fastmcp>=2.12.4",
+    "fastmcp==3.4.2",
+    "mcp==1.28.1",
     "httpx",
     "ipython",
     "langchain-community>=0.3.31",

--- a/src/climateclaw/api/chatbot/streamresponse.py
+++ b/src/climateclaw/api/chatbot/streamresponse.py
@@ -165,6 +165,9 @@ async def streamresponse(
 
     user_name = auth.username
     logger = configure_logging(__name__, thread_id=thread_id, user_id=user_name)
+    logger.info(
+        f"User request: thread-id '{thread_id}', user-input '{input}', chatbot '{chatbot}'"
+    )
 
     create_dir_at_cache(user_name, thread_id)
 

--- a/src/climateclaw/app.py
+++ b/src/climateclaw/app.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from contextlib import asynccontextmanager
 from datetime import timedelta
+from uuid import uuid4
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -22,6 +24,7 @@ from .services.streaming.active_conversations import cleanup_idle
 
 settings = get_settings()
 logger = configure_logging(__name__)
+REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
 # ──────────────────────────────────────────────────────────────────────────────
 # FastAPI app (skeleton)
@@ -132,10 +135,16 @@ app.add_middleware(
 
 @app.middleware("http")
 async def request_id_middleware(request: Request, call_next):
-    token = set_request_id(request.headers.get(REQUEST_ID_HEADER))
+    request_id = request.headers.get(REQUEST_ID_HEADER)
+    if not request_id or not REQUEST_ID_PATTERN.fullmatch(request_id):
+        request_id = str(uuid4())
+
+    token = set_request_id(request_id)
     try:
         # Handover the request to the rest of FastAPI, continue request
-        return await call_next(request)
+        response = await call_next(request)
+        response.headers[REQUEST_ID_HEADER] = request_id
+        return response
     finally:
         # Reset to prev value (token) to prevent leaking, clean-up
         reset_request_id(token)

--- a/src/climateclaw/app.py
+++ b/src/climateclaw/app.py
@@ -4,12 +4,17 @@ import asyncio
 from contextlib import asynccontextmanager
 from datetime import timedelta
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 
 from .api import chatbot, static
-from .core.logging_setup import configure_logging
+from .core.logging_setup import (
+    REQUEST_ID_HEADER,
+    configure_logging,
+    reset_request_id,
+    set_request_id,
+)
 from .core.runtime_checks import run_startup_checks
 from .core.settings import get_settings
 from .services.storage.mongodb_storage import ThreadStorage
@@ -87,6 +92,11 @@ def custom_openapi():
         "in": "header",
         "name": "x-freva-rest-url",
     }
+    security_schemes["RequestId"] = {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Request-Id",
+    }
 
     for path, path_item in openapi_schema.get("paths", {}).items():
         if not path.startswith("/api/chatbot/"):
@@ -96,7 +106,11 @@ def custom_openapi():
             if not isinstance(operation, dict):
                 continue
             operation.setdefault("security", []).append(
-                {"BearerAuth": [], "FrevaRestUrl": []}
+                {
+                    "BearerAuth": [],
+                    "FrevaRestUrl": [],
+                    "RequestId": [],
+                }
             )
 
     app.openapi_schema = openapi_schema
@@ -114,6 +128,18 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.middleware("http")
+async def request_id_middleware(request: Request, call_next):
+    token = set_request_id(request.headers.get(REQUEST_ID_HEADER))
+    try:
+        # Handover the request ti the rest of FastAPI, continue request
+        return await call_next(request)
+    finally:
+        # Reset to prev value (token) to prevent leaking, clean-up
+        reset_request_id(token)
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Route registry

--- a/src/climateclaw/app.py
+++ b/src/climateclaw/app.py
@@ -134,7 +134,7 @@ app.add_middleware(
 async def request_id_middleware(request: Request, call_next):
     token = set_request_id(request.headers.get(REQUEST_ID_HEADER))
     try:
-        # Handover the request ti the rest of FastAPI, continue request
+        # Handover the request to the rest of FastAPI, continue request
         return await call_next(request)
     finally:
         # Reset to prev value (token) to prevent leaking, clean-up

--- a/src/climateclaw/core/logging_setup.py
+++ b/src/climateclaw/core/logging_setup.py
@@ -12,7 +12,6 @@ _CONFIGURED = False
 
 settings = get_settings()
 ENABLE_FILE_LOGGING = os.getenv("CLIMATECLAW_FILE_LOGGING", "1") == "1"
-SYSLOG_TARGET = os.getenv("CLIMATECLAW_SYSLOG_TARGET")
 
 SERVICE_NAME = os.getenv("HOSTNAME") or "app"
 
@@ -125,8 +124,8 @@ def _ensure_base_logging() -> None:
     file_handler.addFilter(base_filter)
     root.addHandler(file_handler)
 
-    if (not settings.DEV) and SYSLOG_TARGET:
-        parsed_target = _parse_syslog_target(SYSLOG_TARGET)
+    if (not settings.DEV) and settings.SYSLOG_TARGET:
+        parsed_target = _parse_syslog_target(settings.SYSLOG_TARGET)
         if parsed_target:
             address, socket_type = parsed_target
             try:
@@ -136,6 +135,7 @@ def _ensure_base_logging() -> None:
                     socktype=socket_type,
                 )
                 syslog_handler.setFormatter(LOG_FORMATTER)
+                syslog_handler.ident = f"{SERVICE_NAME}"
                 syslog_handler.addFilter(base_filter)
                 root.addHandler(syslog_handler)
             except OSError as e:
@@ -143,7 +143,7 @@ def _ensure_base_logging() -> None:
         else:
             root.warning(
                 "Invalid CLIMATECLAW_SYSLOG_TARGET=%r; expected tcp@host:port or udp@host:port",
-                SYSLOG_TARGET,
+                settings.SYSLOG_TARGET,
             )
 
     logging.getLogger("uvicorn").setLevel(logging.WARNING)

--- a/src/climateclaw/core/logging_setup.py
+++ b/src/climateclaw/core/logging_setup.py
@@ -46,7 +46,9 @@ def reset_request_id(token) -> None:
     REQUEST_ID_CONTEXT.reset(token)
 
 
-def _parse_syslog_target(target: str) -> tuple[tuple[str, int], int] | None:
+def _parse_syslog_target(
+    target: str,
+) -> tuple[tuple[str, int], socket.SocketKind] | None:
     """
     Parse HAProxy-style syslog targets like tcp@host:1514.
     Returns the address and socket type expected by SysLogHandler.
@@ -64,7 +66,9 @@ def _parse_syslog_target(target: str) -> tuple[tuple[str, int], int] | None:
     except ValueError:
         return None
 
-    socket_type = socket.SOCK_STREAM if protocol == "tcp" else socket.SOCK_DGRAM
+    socket_type: socket.SocketKind = (
+        socket.SOCK_STREAM if protocol == "tcp" else socket.SOCK_DGRAM
+    )
     return (host, parsed_port), socket_type
 
 

--- a/src/climateclaw/core/logging_setup.py
+++ b/src/climateclaw/core/logging_setup.py
@@ -8,8 +8,6 @@ from climateclaw.core.settings import get_settings
 
 _SILENCED = False
 _CONFIGURED = False
-_THREAD_HANDLERS: dict[str, RotatingFileHandler] = {}
-_NAMED_HANDLERS: dict[str, RotatingFileHandler] = {}
 
 settings = get_settings()
 ENABLE_FILE_LOGGING = os.getenv("CLIMATECLAW_FILE_LOGGING", "1") == "1"
@@ -20,8 +18,6 @@ LOG_DIR = Path(__file__).resolve().parents[3] / "logs"
 MAIN_LOG = LOG_DIR / f"{SERVICE_NAME}.log"
 MAIN_MAX_BYTES = 5_000_000
 MAIN_BACKUP_COUNT = 5
-THREAD_MAX_BYTES = 1_000_000
-THREAD_BACKUP_COUNT = 3
 
 LOG_FORMAT = (
     "%(asctime)s %(levelname)s %(name)s "
@@ -72,24 +68,6 @@ class ContextFilter(logging.Filter):
         return True
 
 
-class ThreadFilter(ContextFilter):
-    """Only allow records for the given thread_id to reach a handler."""
-
-    def __init__(self, thread_id: str) -> None:
-        super().__init__(thread_id=thread_id)
-        self.expected = thread_id or "-"
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        thread_id = getattr(record, "thread_id", self.thread_id) or "-"
-        record.thread_id = thread_id
-        record.user_id = getattr(record, "user_id", self.user_id) or "-"
-        record_request_id = getattr(record, "request_id", None)
-        record.request_id = (
-            get_request_id() if record_request_id in (None, "-") else record_request_id
-        )
-        return thread_id == self.expected
-
-
 def _ensure_base_logging() -> None:
     global _CONFIGURED
     if _CONFIGURED or not ENABLE_FILE_LOGGING:
@@ -124,65 +102,19 @@ def _ensure_base_logging() -> None:
     _CONFIGURED = True
 
 
-def _get_thread_handler(thread_id: str) -> RotatingFileHandler:
-    if thread_id in _THREAD_HANDLERS:
-        return _THREAD_HANDLERS[thread_id]
-
-    LOG_DIR.mkdir(parents=True, exist_ok=True)
-    handler = RotatingFileHandler(
-        LOG_DIR / f"{thread_id}.log",
-        maxBytes=THREAD_MAX_BYTES,
-        backupCount=THREAD_BACKUP_COUNT,
-        encoding="utf-8",
-        delay=True,  # create file lazily on first emit
-    )
-    handler.setFormatter(LOG_FORMATTER)
-    handler.addFilter(ThreadFilter(thread_id=thread_id))
-    _THREAD_HANDLERS[thread_id] = handler
-    return handler
-
-
-def _get_named_handler(log_name: str) -> RotatingFileHandler:
-    if log_name in _NAMED_HANDLERS:
-        return _NAMED_HANDLERS[log_name]
-
-    LOG_DIR.mkdir(parents=True, exist_ok=True)
-    handler = RotatingFileHandler(
-        LOG_DIR / f"{log_name}.log",
-        maxBytes=THREAD_MAX_BYTES,
-        backupCount=THREAD_BACKUP_COUNT,
-        encoding="utf-8",
-        delay=True,  # create file lazily on first emit
-    )
-    handler.setFormatter(LOG_FORMATTER)
-    handler.addFilter(ContextFilter())
-    _NAMED_HANDLERS[log_name] = handler
-    return handler
-
-
 def configure_logging(
     logger_name: str | None = None,
     thread_id: str | None = None,
     user_id: str | None = None,
     request_id: str | None = None,
-    named_log: str | None = None,
 ) -> logging.LoggerAdapter:
     """
     Configure root logging once and return a logger adapter with optional context.
-    When thread_id is provided, logs are also written to logs/log_<thread_id>.txt.
-    When named_log is provided, logs are also written to logs/<named_log>.log.
+    When thread_id is provided, it is added as log context.
     """
     _ensure_base_logging()
 
     logger = logging.getLogger(logger_name)
-    if thread_id:
-        handler = _get_thread_handler(thread_id)
-        if handler not in logger.handlers:
-            logger.addHandler(handler)
-    if named_log:
-        handler = _get_named_handler(named_log)
-        if handler not in logger.handlers:
-            logger.addHandler(handler)
 
     logging.getLogger("fakeredis").setLevel(logging.WARNING)
     logging.getLogger("docket").setLevel(logging.WARNING)

--- a/src/climateclaw/core/logging_setup.py
+++ b/src/climateclaw/core/logging_setup.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from contextvars import ContextVar
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
@@ -25,24 +26,49 @@ THREAD_BACKUP_COUNT = 3
 LOG_FORMAT = (
     "%(asctime)s %(levelname)s %(name)s "
     f"[service={SERVICE_NAME}]"
-    "[thread=%(thread_id)s user=%(user_id)s] %(message)s"
+    "[request=%(request_id)s thread=%(thread_id)s user=%(user_id)s] %(message)s"
 )
 LOG_FORMATTER = logging.Formatter(LOG_FORMAT)
+
+REQUEST_ID_HEADER = "X-Request-Id"
+REQUEST_ID_CONTEXT: ContextVar[str | None] = ContextVar(
+    "request_id_context", default=None
+)
+
+
+def get_request_id() -> str:
+    return REQUEST_ID_CONTEXT.get() or "-"
+
+
+def set_request_id(request_id: str | None):
+    return REQUEST_ID_CONTEXT.set(request_id or None)
+
+
+def reset_request_id(token) -> None:
+    REQUEST_ID_CONTEXT.reset(token)
 
 
 class ContextFilter(logging.Filter):
     """Ensures thread_id/user_id keys exist on log records."""
 
     def __init__(
-        self, thread_id: str | None = None, user_id: str | None = None
+        self,
+        thread_id: str | None = None,
+        user_id: str | None = None,
+        request_id: str | None = None,
     ) -> None:
         super().__init__()
         self.thread_id = thread_id or "-"
         self.user_id = user_id or "-"
+        self.request_id = request_id or "-"
 
     def filter(self, record: logging.LogRecord) -> bool:
         record.thread_id = getattr(record, "thread_id", self.thread_id) or "-"
         record.user_id = getattr(record, "user_id", self.user_id) or "-"
+        record_request_id = getattr(record, "request_id", None)
+        record.request_id = (
+            get_request_id() if record_request_id in (None, "-") else record_request_id
+        )
         return True
 
 
@@ -57,6 +83,10 @@ class ThreadFilter(ContextFilter):
         thread_id = getattr(record, "thread_id", self.thread_id) or "-"
         record.thread_id = thread_id
         record.user_id = getattr(record, "user_id", self.user_id) or "-"
+        record_request_id = getattr(record, "request_id", None)
+        record.request_id = (
+            get_request_id() if record_request_id in (None, "-") else record_request_id
+        )
         return thread_id == self.expected
 
 
@@ -83,6 +113,7 @@ def _ensure_base_logging() -> None:
         maxBytes=MAIN_MAX_BYTES,
         backupCount=MAIN_BACKUP_COUNT,
         encoding="utf-8",
+        delay=True,  # create file lazily on first emit
     )
     file_handler.setFormatter(LOG_FORMATTER)
     file_handler.addFilter(base_filter)
@@ -133,6 +164,7 @@ def configure_logging(
     logger_name: str | None = None,
     thread_id: str | None = None,
     user_id: str | None = None,
+    request_id: str | None = None,
     named_log: str | None = None,
 ) -> logging.LoggerAdapter:
     """
@@ -157,7 +189,12 @@ def configure_logging(
     logging.getLogger("pymongo").setLevel(logging.WARNING)
 
     return logging.LoggerAdapter(
-        logger, {"thread_id": thread_id or "-", "user_id": user_id or "-"}
+        logger,
+        {
+            "thread_id": thread_id or "-",
+            "user_id": user_id or "-",
+            "request_id": request_id or get_request_id(),
+        },
     )
 
 

--- a/src/climateclaw/core/logging_setup.py
+++ b/src/climateclaw/core/logging_setup.py
@@ -1,7 +1,8 @@
 import logging
 import os
+import socket
 from contextvars import ContextVar
-from logging.handlers import RotatingFileHandler
+from logging.handlers import RotatingFileHandler, SysLogHandler
 from pathlib import Path
 
 from climateclaw.core.settings import get_settings
@@ -11,6 +12,7 @@ _CONFIGURED = False
 
 settings = get_settings()
 ENABLE_FILE_LOGGING = os.getenv("CLIMATECLAW_FILE_LOGGING", "1") == "1"
+SYSLOG_TARGET = os.getenv("CLIMATECLAW_SYSLOG_TARGET")
 
 SERVICE_NAME = os.getenv("HOSTNAME") or "app"
 
@@ -42,6 +44,28 @@ def set_request_id(request_id: str | None):
 
 def reset_request_id(token) -> None:
     REQUEST_ID_CONTEXT.reset(token)
+
+
+def _parse_syslog_target(target: str) -> tuple[tuple[str, int], int] | None:
+    """
+    Parse HAProxy-style syslog targets like tcp@host:1514.
+    Returns the address and socket type expected by SysLogHandler.
+    """
+    protocol, separator, address = target.partition("@")
+    if separator != "@" or protocol not in {"tcp", "udp"}:
+        return None
+
+    host, separator, port = address.rpartition(":")
+    if separator != ":" or not host:
+        return None
+
+    try:
+        parsed_port = int(port)
+    except ValueError:
+        return None
+
+    socket_type = socket.SOCK_STREAM if protocol == "tcp" else socket.SOCK_DGRAM
+    return (host, parsed_port), socket_type
 
 
 class ContextFilter(logging.Filter):
@@ -96,6 +120,27 @@ def _ensure_base_logging() -> None:
     file_handler.setFormatter(LOG_FORMATTER)
     file_handler.addFilter(base_filter)
     root.addHandler(file_handler)
+
+    if (not settings.DEV) and SYSLOG_TARGET:
+        parsed_target = _parse_syslog_target(SYSLOG_TARGET)
+        if parsed_target:
+            address, socket_type = parsed_target
+            try:
+                syslog_handler = SysLogHandler(
+                    address=address,
+                    facility=SysLogHandler.LOG_LOCAL0,
+                    socktype=socket_type,
+                )
+                syslog_handler.setFormatter(LOG_FORMATTER)
+                syslog_handler.addFilter(base_filter)
+                root.addHandler(syslog_handler)
+            except OSError as e:
+                root.warning("Failed to configure remote syslog logging: %s", e)
+        else:
+            root.warning(
+                "Invalid CLIMATECLAW_SYSLOG_TARGET=%r; expected tcp@host:port or udp@host:port",
+                SYSLOG_TARGET,
+            )
 
     logging.getLogger("uvicorn").setLevel(logging.WARNING)
 

--- a/src/climateclaw/core/settings.py
+++ b/src/climateclaw/core/settings.py
@@ -36,6 +36,7 @@ class Settings:
         os.getenv("CLIMATECLAW_MCP_REQUEST_TIMEOUT_SEC", "600")
     )
     DEV: bool = os.getenv("CLIMATECLAW_DEV", "").lower() in {"1", "true", "yes"}
+    SYSLOG_TARGET = os.getenv("CLIMATECLAW_SYSLOG_TARGET")
 
 
 # Simple singleton-style accessor

--- a/src/climateclaw/services/mcp/client.py
+++ b/src/climateclaw/services/mcp/client.py
@@ -8,7 +8,11 @@ from typing import Any
 
 import httpx
 
-from climateclaw.core.logging_setup import configure_logging
+from climateclaw.core.logging_setup import (
+    REQUEST_ID_HEADER,
+    configure_logging,
+    get_request_id,
+)
 from climateclaw.core.settings import get_settings
 
 DEFAULT_LOGGER = configure_logging(__name__)
@@ -189,6 +193,7 @@ class McpClient:
             "Mcp-Protocol-Version": MCP_PROTOCOL_VERSION,
         }
         h.update(self.default_headers)
+        h[REQUEST_ID_HEADER] = get_request_id()
 
         if include_session and session_id:
             h["Mcp-Session-Id"] = session_id

--- a/src/climateclaw/services/service_factory.py
+++ b/src/climateclaw/services/service_factory.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 from fastapi import Depends, HTTPException, Request
 
-from climateclaw.core.logging_setup import configure_logging
+from climateclaw.core.logging_setup import (
+    REQUEST_ID_HEADER,
+    configure_logging,
+    get_request_id,
+)
 from climateclaw.core.settings import get_server_url_dict, get_settings
 
 from .authentication.auth import Authenticator
@@ -50,6 +54,7 @@ async def get_mcp_manager(
     # Defaults to send; per-call headers (rest) are added at call time.
     default_headers: dict[str, str] = {
         "thread-id": thread_id,
+        REQUEST_ID_HEADER: get_request_id(),
     }
 
     logger = configure_logging(

--- a/src/climateclaw/services/service_factory.py
+++ b/src/climateclaw/services/service_factory.py
@@ -2,11 +2,7 @@ from pathlib import Path
 
 from fastapi import Depends, HTTPException, Request
 
-from climateclaw.core.logging_setup import (
-    REQUEST_ID_HEADER,
-    configure_logging,
-    get_request_id,
-)
+from climateclaw.core.logging_setup import configure_logging
 from climateclaw.core.settings import get_server_url_dict, get_settings
 
 from .authentication.auth import Authenticator
@@ -54,7 +50,6 @@ async def get_mcp_manager(
     # Defaults to send; per-call headers (rest) are added at call time.
     default_headers: dict[str, str] = {
         "thread-id": thread_id,
-        REQUEST_ID_HEADER: get_request_id(),
     }
 
     logger = configure_logging(

--- a/src/climateclaw/services/streaming/litellm_client.py
+++ b/src/climateclaw/services/streaming/litellm_client.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 
+from climateclaw.core.logging_setup import REQUEST_ID_HEADER, get_request_id
 from climateclaw.core.settings import get_settings
 
 # ---------------------------------------------------------------------------
@@ -33,6 +34,9 @@ def _passthrough_params(params: dict[str, Any] | None) -> dict[str, Any]:
 
 def _headers() -> dict[str, str]:
     h = {"Content-Type": "application/json"}
+    request_id = get_request_id()
+    if request_id != "-":
+        h[REQUEST_ID_HEADER] = request_id
     # Authorization header is not required for Ollama models,
     # but sending it (when available) doesn’t hurt and satisfies OpenAI-routed calls.
     if AUTH_TOKEN:
@@ -88,6 +92,15 @@ async def acomplete(
     payload.update(_passthrough_params(None))
     if request_params:
         payload.update(_passthrough_params(request_params))
+
+    request_id = get_request_id()
+    if request_id != "-":
+        metadata = payload.get("metadata")
+        if isinstance(metadata, dict):
+            metadata = {**metadata, "request_id": request_id}
+        else:
+            metadata = {"request_id": request_id}
+        payload["metadata"] = metadata
 
     if not stream:
         return await _post_json(url, payload)

--- a/src/climateclaw/services/streaming/litellm_client.py
+++ b/src/climateclaw/services/streaming/litellm_client.py
@@ -35,8 +35,7 @@ def _passthrough_params(params: dict[str, Any] | None) -> dict[str, Any]:
 def _headers() -> dict[str, str]:
     h = {"Content-Type": "application/json"}
     request_id = get_request_id()
-    if request_id != "-":
-        h[REQUEST_ID_HEADER] = request_id
+    h[REQUEST_ID_HEADER] = request_id
     # Authorization header is not required for Ollama models,
     # but sending it (when available) doesn’t hurt and satisfies OpenAI-routed calls.
     if AUTH_TOKEN:
@@ -94,13 +93,12 @@ async def acomplete(
         payload.update(_passthrough_params(request_params))
 
     request_id = get_request_id()
-    if request_id != "-":
-        metadata = payload.get("metadata")
-        if isinstance(metadata, dict):
-            metadata = {**metadata, "request_id": request_id}
-        else:
-            metadata = {"request_id": request_id}
-        payload["metadata"] = metadata
+    metadata = payload.get("metadata")
+    if isinstance(metadata, dict):
+        metadata = {**metadata, "request_id": request_id}
+    else:
+        metadata = {"request_id": request_id}
+    payload["metadata"] = metadata
 
     if not stream:
         return await _post_json(url, payload)

--- a/src/climateclaw/tools/code/code_execution.py
+++ b/src/climateclaw/tools/code/code_execution.py
@@ -24,7 +24,7 @@ from .kernels import (
 
 SERVICE_NAME = os.getenv("HOSTNAME") or "code_server"
 
-logger = configure_logging(__name__, named_log=SERVICE_NAME)
+logger = configure_logging(__name__)
 
 
 # ── Config ───────────────────────────────────────────────────────────────────

--- a/src/climateclaw/tools/code/kernels.py
+++ b/src/climateclaw/tools/code/kernels.py
@@ -9,7 +9,7 @@ from climateclaw.core.logging_setup import configure_logging
 
 SERVICE_NAME = os.getenv("HOSTNAME") or "code_server"
 
-logger = configure_logging(__name__, named_log=SERVICE_NAME)
+logger = configure_logging(__name__)
 
 
 # ── Kernel persistence ───────────────────────────────────────────────────────

--- a/src/climateclaw/tools/code/safety_check.py
+++ b/src/climateclaw/tools/code/safety_check.py
@@ -6,7 +6,7 @@ from climateclaw.core.logging_setup import configure_logging
 
 SERVICE_NAME = os.getenv("HOSTNAME") or "code_server"
 
-logger = configure_logging(__name__, named_log=SERVICE_NAME)
+logger = configure_logging(__name__)
 
 
 # Code safety rules

--- a/src/climateclaw/tools/code/server.py
+++ b/src/climateclaw/tools/code/server.py
@@ -23,9 +23,7 @@ from .helpers import sanitize_code, should_restart_after
 from .kernels import KERNEL_REGISTRY, get_sid_lock, shutdown_kernel
 from .safety_check import check_code_safety
 
-SERVICE_NAME = os.getenv("HOSTNAME") or "code_server"
-
-logger = configure_logging(__name__, named_log=SERVICE_NAME)
+logger = configure_logging(__name__)
 
 mcp = FastMCP("code-interpreter-server")
 

--- a/src/climateclaw/tools/header_gate.py
+++ b/src/climateclaw/tools/header_gate.py
@@ -4,6 +4,9 @@ from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
 from typing import Any, Optional
 
+from mcp.server.streamable_http import ServerMessageMetadata
+from mcp.shared.session import RequestResponder
+
 from climateclaw.core.logging_setup import (
     REQUEST_ID_HEADER,
     configure_logging,
@@ -13,6 +16,53 @@ from climateclaw.core.logging_setup import (
 
 log = logging.getLogger(__name__)
 configure_logging()
+
+_MCP_REQUEST_ID_CONTEXT_PATCHED = False
+
+
+def _debug_request_id_from_mcp_message(message) -> str | None:
+    if not isinstance(message, RequestResponder):
+        return None
+
+    metadata = getattr(message, "message_metadata", None)
+    if not isinstance(metadata, ServerMessageMetadata):
+        return None
+
+    request = getattr(metadata, "request_context", None)
+    headers = getattr(request, "headers", None)
+    if headers is None:
+        return None
+
+    return headers.get(REQUEST_ID_HEADER)
+
+
+def _patch_debug_request_id_context() -> None:
+    """
+    Restore X-Request-Id per MCP JSON-RPC message.
+
+    Streamable HTTP keeps one server task per stateful MCP session. That task is
+    created when the session is initialized, so task-local ContextVars otherwise
+    keep the request id from session creation for later tool calls.
+    """
+    global _MCP_REQUEST_ID_CONTEXT_PATCHED
+    if _MCP_REQUEST_ID_CONTEXT_PATCHED:
+        return
+
+    from mcp.server.lowlevel.server import Server
+
+    original_handle_message = Server._handle_message
+
+    async def handle_message_with_request_id_context(self, message, *args, **kwargs):
+        request_id = _debug_request_id_from_mcp_message(message)
+        token = set_request_id(request_id) if request_id else None
+        try:
+            return await original_handle_message(self, message, *args, **kwargs)
+        finally:
+            if token is not None:
+                reset_request_id(token)
+
+    setattr(Server, "_handle_message", handle_message_with_request_id_context)
+    _MCP_REQUEST_ID_CONTEXT_PATCHED = True
 
 
 async def _send_response(
@@ -92,6 +142,7 @@ def make_header_gate(
       - sets ContextVars for downstream code.
       - (optional) cleans up on DELETE {mcp_path} using Mcp-Session-Id.
     """
+    _patch_debug_request_id_context()
     log = logger or logging.getLogger("header_gate")
 
     class HeaderCaptureASGI:

--- a/src/climateclaw/tools/header_gate.py
+++ b/src/climateclaw/tools/header_gate.py
@@ -4,10 +4,76 @@ from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
 from typing import Any, Optional
 
-from climateclaw.core.logging_setup import configure_logging
+from climateclaw.core.logging_setup import (
+    REQUEST_ID_HEADER,
+    configure_logging,
+    reset_request_id,
+    set_request_id,
+)
 
 log = logging.getLogger(__name__)
 configure_logging()
+
+
+async def _send_response(
+    send: Callable[..., Awaitable],
+    *,
+    status: int,
+    headers: list[tuple[bytes, bytes]] | None = None,
+    body: bytes = b"",
+) -> None:
+    await send(
+        {
+            "type": "http.response.start",
+            "status": status,
+            "headers": headers or [],
+        }
+    )
+    await send({"type": "http.response.body", "body": body, "more_body": False})
+
+
+async def _send_json_response(
+    send: Callable[..., Awaitable],
+    *,
+    status: int,
+    body: bytes,
+) -> None:
+    await _send_response(
+        send,
+        status=status,
+        headers=[(b"content-type", b"application/json")],
+        body=body,
+    )
+
+
+async def _send_invalid_mongodb_header_response(
+    send: Callable[..., Awaitable],
+    header_name: str,
+) -> None:
+    body = (
+        b"event: message\r\n"
+        b'data: {"jsonrpc":"2.0","error":{"code":-32600,'
+        b'"message":"Missing or invalid header \'' + header_name.encode("utf-8") + b"' "
+        b'(expected mongodb:// or mongodb+srv://)"}}\r\n\r\n'
+    )
+    await _send_response(
+        send,
+        status=400,
+        headers=[
+            (b"content-type", b"text/event-stream"),
+            (b"cache-control", b"no-cache, no-transform"),
+            (b"connection", b"keep-alive"),
+        ],
+        body=body,
+    )
+
+
+def _headers_from_scope(scope: dict[str, Any]) -> dict[str, str]:
+    # Normalize headers to a case-insensitive dict
+    return {
+        k.decode("latin-1").lower(): v.decode("latin-1")
+        for k, v in scope.get("headers", [])
+    }
 
 
 def make_header_gate(
@@ -45,153 +111,106 @@ def make_header_gate(
 
             if path == "/healthz":
                 body = json.dumps({"status": "ok"}).encode("utf-8")
-                await send(
-                    {
-                        "type": "http.response.start",
-                        "status": 200,
-                        "headers": [(b"content-type", b"application/json")],
-                    }
-                )
-                await send(
-                    {"type": "http.response.body", "body": body, "more_body": False}
-                )
+                await _send_json_response(send, status=200, body=body)
                 return
 
             if path != mcp_path:
                 return await self.app(scope, receive, send)
 
-            # Normalize headers to a case-insensitive dict
-            hdrs = {
-                k.decode("latin-1").lower(): v.decode("latin-1")
-                for k, v in scope.get("headers", [])
-            }
+            hdrs = _headers_from_scope(scope)
+
+            # This is the frontend/proxy request ID. The logging filter reads
+            # it from the ContextVar; it is different from Mcp-Request-Id below.
+            request_id_token = set_request_id(hdrs.get(REQUEST_ID_HEADER.lower()))
 
             method = (scope.get("method") or "").upper()
-            sid = hdrs.get("mcp-session-id", "")
-
-            # handle session close
-            if method == "DELETE":
-                try:
-                    log.info("DELETE %s received. Session id=%r", mcp_path, sid)
-                except Exception:
-                    pass
-
-                if on_session_close and sid:
-                    try:
-                        on_session_close(sid)
-                    except Exception:
-                        log.exception("on_session_close failed for sid=%s", sid)
-
-                # Respond 204 No Content
-                await send(
-                    {"type": "http.response.start", "status": 204, "headers": []}
-                )
-                await send(
-                    {"type": "http.response.body", "body": b"", "more_body": False}
-                )
-                return
-
-            # handle session interrupt
-            if method == "POST" and "mcp-cancel" in hdrs:
-                request_id = hdrs.get("mcp-request-id", "")
-
-                try:
-                    log.info(
-                        "CANCEL %s received. session_id=%r request_id=%r",
-                        mcp_path,
-                        sid,
-                        request_id,
-                    )
-                except Exception:
-                    pass
-
-                if not sid or not request_id:
-                    await send(
-                        {
-                            "type": "http.response.start",
-                            "status": 400,
-                            "headers": [(b"content-type", b"application/json")],
-                        }
-                    )
-                    await send(
-                        {
-                            "type": "http.response.body",
-                            "body": b'{"error":"Missing Mcp-Session-Id or Mcp-Request-Id"}',
-                            "more_body": False,
-                        }
-                    )
-                    return
-
-                if on_cancel_request:
-                    try:
-                        await on_cancel_request(sid, request_id)
-                    except Exception:
-                        log.exception(
-                            "on_cancel_request failed for sid=%s request_id=%s",
-                            sid,
-                            request_id,
-                        )
-
-                await send(
-                    {"type": "http.response.start", "status": 204, "headers": []}
-                )
-                await send(
-                    {"type": "http.response.body", "body": b"", "more_body": False}
-                )
-                return
-
-            tokens: list[tuple[ContextVar, Any]] = []
+            mcp_session_id = hdrs.get("mcp-session-id", "")
 
             try:
-                for ctx, header_name in zip(ctx_list, header_name_list):
-                    v = hdrs.get(header_name)
+                # handle session close
+                if method == "DELETE":
+                    try:
+                        log.info(
+                            "DELETE %s received. session_id=%r",
+                            mcp_path,
+                            mcp_session_id,
+                        )
+                    except Exception:
+                        pass
 
-                    # Enforce required conditions on header
-                    # We do not do the same for CI because it doesn't have to be that strict, it can operate without freva access. We warn about this
-                    if header_name == "mongodb-uri" and (
-                        not v
-                        or not (
-                            v.startswith("mongodb://") or v.startswith("mongodb+srv://")
+                    if on_session_close and mcp_session_id:
+                        try:
+                            on_session_close(mcp_session_id)
+                        except Exception:
+                            log.exception(
+                                "on_session_close failed for sid=%s", mcp_session_id
+                            )
+
+                    await _send_response(send, status=204)
+                    return
+
+                # handle session interrupt
+                if method == "POST" and "mcp-cancel" in hdrs:
+                    mcp_request_id = hdrs.get("mcp-request-id", "")
+
+                    try:
+                        log.info(
+                            "CANCEL %s received. session_id=%r request_id=%r",
+                            mcp_path,
+                            mcp_session_id,
+                            mcp_request_id,
                         )
-                    ):
-                        body = (
-                            b"event: message\r\n"
-                            b'data: {"jsonrpc":"2.0","error":{"code":-32600,'
-                            b'"message":"Missing or invalid header \''
-                            + header_name.encode("utf-8")
-                            + b"' "
-                            b'(expected mongodb:// or mongodb+srv://)"}}\r\n\r\n'
-                        )
-                        await send(
-                            {
-                                "type": "http.response.start",
-                                "status": 400,
-                                "headers": [
-                                    (b"content-type", b"text/event-stream"),
-                                    (b"cache-control", b"no-cache, no-transform"),
-                                    (b"connection", b"keep-alive"),
-                                ],
-                            }
-                        )
-                        await send(
-                            {
-                                "type": "http.response.body",
-                                "body": body,
-                                "more_body": False,
-                            }
+                    except Exception:
+                        pass
+
+                    if not mcp_session_id or not mcp_request_id:
+                        await _send_json_response(
+                            send,
+                            status=400,
+                            body=b'{"error":"Missing Mcp-Session-Id or Mcp-Request-Id"}',
                         )
                         return
 
-                    # Set ContextVars for downstream code
-                    tok_v = ctx.set(v)
-                    tokens.append((ctx, tok_v))
+                    if on_cancel_request:
+                        try:
+                            await on_cancel_request(mcp_session_id, mcp_request_id)
+                        except Exception:
+                            log.exception(
+                                "on_cancel_request failed for sid=%s request_id=%s",
+                                mcp_session_id,
+                                mcp_request_id,
+                            )
 
-                # Call the wrapped app once, with all ContextVars set
-                return await self.app(scope, receive, send)
+                    await _send_response(send, status=204)
+                    return
 
+                tokens: list[tuple[ContextVar, Any]] = []
+
+                try:
+                    for ctx, header_name in zip(ctx_list, header_name_list):
+                        v = hdrs.get(header_name)
+
+                        if header_name == "mongodb-uri" and (
+                            not v
+                            or not (
+                                v.startswith("mongodb://")
+                                or v.startswith("mongodb+srv://")
+                            )
+                        ):
+                            await _send_invalid_mongodb_header_response(
+                                send, header_name
+                            )
+                            return
+
+                        tok_v = ctx.set(v)
+                        tokens.append((ctx, tok_v))
+
+                    return await self.app(scope, receive, send)
+
+                finally:
+                    for ctx, tok_v in reversed(tokens):
+                        ctx.reset(tok_v)
             finally:
-                # Reset all ContextVars
-                for ctx, tok_v in reversed(tokens):
-                    ctx.reset(tok_v)
+                reset_request_id(request_id_token)
 
     return HeaderCaptureASGI(inner_app)

--- a/src/climateclaw/tools/rag/document_loaders.py
+++ b/src/climateclaw/tools/rag/document_loaders.py
@@ -14,7 +14,7 @@ from climateclaw.core.logging_setup import configure_logging
 
 SERVICE_NAME = os.getenv("HOSTNAME") or "rag_server"
 
-logger = configure_logging(__name__, named_log=SERVICE_NAME)
+logger = configure_logging(__name__)
 
 
 loader_cls_dict = {

--- a/src/climateclaw/tools/rag/helpers.py
+++ b/src/climateclaw/tools/rag/helpers.py
@@ -10,7 +10,7 @@ from climateclaw.core.logging_setup import configure_logging
 
 SERVICE_NAME = os.getenv("HOSTNAME") or "rag_server"
 
-logger = configure_logging(__name__, named_log=SERVICE_NAME)
+logger = configure_logging(__name__)
 
 
 def json_to_str(data) -> str:

--- a/src/climateclaw/tools/rag/server.py
+++ b/src/climateclaw/tools/rag/server.py
@@ -17,9 +17,7 @@ from climateclaw.tools.rag.helpers import (
 )
 from climateclaw.tools.rag.text_splitters import CustomDocumentSplitter
 
-SERVICE_NAME = os.getenv("HOSTNAME") or "rag_server"
-
-logger = configure_logging(__name__, named_log=SERVICE_NAME)
+logger = configure_logging(__name__)
 
 
 LITE_LLM_ADDRESS: str = os.getenv("CLIMATECLAW_LITE_LLM_ADDRESS", "http://litellm:4000")

--- a/src/climateclaw/tools/web_search/server.py
+++ b/src/climateclaw/tools/web_search/server.py
@@ -13,9 +13,7 @@ from climateclaw.tools.active_requests import (
 )
 from climateclaw.tools.header_gate import make_header_gate
 
-SERVICE_NAME = os.getenv("HOSTNAME") or "web_search_server"
-
-logger = configure_logging(__name__, named_log=SERVICE_NAME)
+logger = configure_logging(__name__)
 
 
 OPENAI_API_KEY = os.getenv("CLIMATECLAW_OPENAI_API_KEY", "")

--- a/tests/api_integration_tests/test_request_id.py
+++ b/tests/api_integration_tests/test_request_id.py
@@ -1,0 +1,40 @@
+import re
+
+import pytest
+
+from climateclaw.core.logging_setup import REQUEST_ID_HEADER
+
+UUID4_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+@pytest.mark.asyncio
+async def test_request_id_header_round_trips_when_valid(client):
+    request_id = "client.id_123-ABC"
+
+    async with client:
+        response = await client.get("/healthz", headers={REQUEST_ID_HEADER: request_id})
+
+    assert response.status_code == 200
+    assert response.headers[REQUEST_ID_HEADER] == request_id
+
+
+@pytest.mark.asyncio
+async def test_request_id_header_falls_back_to_uuid4_when_missing(client):
+    async with client:
+        response = await client.get("/healthz")
+
+    assert response.status_code == 200
+    assert UUID4_PATTERN.fullmatch(response.headers[REQUEST_ID_HEADER])
+
+
+@pytest.mark.asyncio
+async def test_request_id_header_falls_back_to_uuid4_when_invalid(client):
+    async with client:
+        response = await client.get(
+            "/healthz", headers={REQUEST_ID_HEADER: "bad/request/id"}
+        )
+
+    assert response.status_code == 200
+    assert UUID4_PATTERN.fullmatch(response.headers[REQUEST_ID_HEADER])


### PR DESCRIPTION
This PR improves production observability by making request-ids available across the ClimateClaw API, MCP tool services, HAProxy, and LiteLLM calls. It adds request-scoped logging context so logs from different services can be correlated by `X-Request-Id`, while simplifying file logging by removing per-thread and named log files. Closes #91 

**Changes:**
- Add FastAPI middleware to capture `X-Request-Id` and store it in request-scoped logging context.
- Include `request_id` in the shared log format alongside service, thread, and user context.
- Add optional remote syslog forwarding via `CLIMATECLAW_SYSLOG_TARGET`.
- Update HAProxy generation to forward `X-Request-Id`, capture it, and include it in access logs.
- Forward the current request-id to MCP manager and LiteLLM requests.
- Add request-id metadata to LiteLLM payloads and configure docker logging for the LiteLLM container.
- Capture and reset request-id context at MCP header gate.
- Remove per-thread and named log file handlers so services use the centralized logging setup.

**Misc:**
- Refactor MCP header gate response handling

Tested for persistence of request-id in the logs in local, remote syslogs to be tested.